### PR TITLE
Replace tokio with tokio-io, tokio-timer and tokio-executor.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,15 @@ version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
+futures = "0.1"
 log = ">= 0.4"
 quick-error= "1"
 parking_lot = "0.5"
-tokio = ">= 0.1.5"
+tokio-executor = "0.1"
+tokio-io = "0.1"
+tokio-timer = "0.2"
 
 [dev-dependencies]
 env_logger = "0.5"
+tokio = "0.1"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use std::io;
-use tokio::executor::SpawnError;
+use tokio_executor::SpawnError;
 
 pub type Result<T> = ::std::result::Result<T, Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,17 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+extern crate futures;
 #[macro_use]
 extern crate log;
 extern crate parking_lot;
 #[macro_use]
 extern crate quick_error;
+extern crate tokio_executor;
+extern crate tokio_io;
+extern crate tokio_timer;
+
+#[cfg(test)]
 extern crate tokio;
 
 mod algorithms;

--- a/src/limited.rs
+++ b/src/limited.rs
@@ -19,11 +19,11 @@
 // DEALINGS IN THE SOFTWARE.
 
 use algorithms::Id;
+use futures::prelude::*;
 use error::{Error, Result};
 use limiter::Limiter;
-use std::cmp::min;
-use std::io;
-use tokio::prelude::*;
+use std::{cmp::min, io};
+use tokio_io::{AsyncRead, AsyncWrite};
 
 /// A rate-limited resource.
 pub struct Limited<T> {


### PR DESCRIPTION
Except in tests.

Addresses https://github.com/libp2p/rust-libp2p/issues/204.