### PR TITLE
Handle background-timer errors.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -38,5 +38,8 @@ quick_error! {
         NoCapacity {
             description("no capacity left")
         }
+        TimerError {
+            description("error executing background timer")
+        }
     }
 }

--- a/src/limited.rs
+++ b/src/limited.rs
@@ -61,7 +61,7 @@ impl<T: AsyncRead> io::Read for Limited<T> {
                 }
             }
             Err(Error::NoCapacity) => {
-                self.lim.enqueue(self.id);
+                self.lim.enqueue(self.id).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
                 Err(io::Error::new(io::ErrorKind::WouldBlock, "rate limited"))
             }
             Err(Error::Io(e)) => Err(e),
@@ -88,7 +88,7 @@ impl<T: io::Write> io::Write for Limited<T> {
                 }
             }
             Err(Error::NoCapacity) => {
-                self.lim.enqueue(self.id);
+                self.lim.enqueue(self.id).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
                 Err(io::Error::new(io::ErrorKind::WouldBlock, "rate limited"))
             }
             Err(Error::Io(e)) => Err(e),


### PR DESCRIPTION
In the unlikely event that the background timer errors, set an error flag in `Limiter` such that the error condition propagates.