### PR TITLE
Update parking_lot and fix deprecation warnings on Box<Future>s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0 OR MIT"
 description = "Rate-limited async I/O."
 repository = "https://github.com/paritytech/aio-limited"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 futures = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aio-limited"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0 OR MIT"
 description = "Rate-limited async I/O."
@@ -10,12 +10,12 @@ readme = "README.md"
 [dependencies]
 futures = "0.1"
 log = "0.4"
-parking_lot = "0.5"
+parking_lot = "0.9"
 tokio-executor = "0.1"
 tokio-io = "0.1"
 tokio-timer = "0.2"
 
 [dev-dependencies]
-env_logger = "0.5"
+env_logger = "0.6"
 tokio = "0.1"
 

--- a/src/algorithms/bucket.rs
+++ b/src/algorithms/bucket.rs
@@ -9,7 +9,7 @@
 // at https://opensource.org/licenses/MIT.
 
 use crate::{algorithms::{Id, Token}, error::{Error, Result}};
-use parking_lot::Mutex;
+use parking_lot::{Mutex, lock_api::MutexGuard};
 use std::{cmp::min, sync::atomic::{AtomicUsize, Ordering}};
 
 /// A bucket has a certain capacity which is made available as `Token`s
@@ -73,7 +73,7 @@ impl Bucket {
 
         cap.value -= quant;
         let t = Token::new(cap.index, quant);
-        cap.unlock_fair();
+        MutexGuard::unlock_fair(cap);
         Ok(t)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,16 +8,6 @@
 // at https://www.apache.org/licenses/LICENSE-2.0 and a copy of the MIT license
 // at https://opensource.org/licenses/MIT.
 
-extern crate futures;
-extern crate log;
-extern crate parking_lot;
-extern crate tokio_executor;
-extern crate tokio_io;
-extern crate tokio_timer;
-
-#[cfg(test)]
-extern crate tokio;
-
 mod algorithms;
 mod error;
 mod limited;


### PR DESCRIPTION
The used version of `parking_lot` is quite old and it would be great to get it updated for https://github.com/paritytech/substrate/issues/808. This would necessitate a `0.1.1` release.